### PR TITLE
Two small fixes to Makefile (fixes #3).

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,9 @@ init:
 	pipenv install --dev # Install packages
 
 lock:
-	echo $(SUDOERS_ENTRY) | sudo EDITOR='tee -a' visudo -f $(SUDOERS_FILE)
+	echo $(SUDOERS_ENTRY) | sudo EDITOR='tee' visudo -f $(SUDOERS_FILE)
 	sudo chown -R root:root ./
 	sudo chown $(CURRENT_USER):$(CURRENT_USER) ./data/rules.yaml
-	sudo chown $(CURRENT_USER):$(CURRENT_USER) ./readme.org
 	sudo chown $(CURRENT_USER):$(CURRENT_USER) ./readme.org
 	sudo chown $(CURRENT_USER):$(CURRENT_USER) ./.gitignore
 	sudo chown -R $(CURRENT_USER):$(CURRENT_USER) ./.git


### PR DESCRIPTION
1. /sudoers.d/chomper gets overwritten rather than appended to.
2. Remove unnecessary chown.