### PR TITLE
Add missing arguments for enact_block.

### DIFF
--- a/chomper/block.py
+++ b/chomper/block.py
@@ -75,7 +75,7 @@ def main(rules_path: str, settings_json_path: str, rule: str,
                                 new_block_start, new_block_end)
         enact_block(listening_port, new_block_settings['addresses'],
                     new_block_settings['block_type'],
-                    mitmdump_bin_path)
+                    mitmdump_bin_path, rule, new_block_settings['end'])
         set_block_length(new_block_end, reset_command)
         write_block_to_json(new_block_settings, settings_json_path)
         print("New block in effect until {}."


### PR DESCRIPTION
After fresh installation and issuing `chomper coding 10` I get this error:
```
❯ ./bin/chomper coding 1     
Traceback (most recent call last):
  File "/home/sarg/devel/chomper/chomper/block.py", line 144, in <module>
    main()
  File "/home/sarg/.local/share/virtualenvs/chomper-LZFI31mM/lib/python3.6/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/home/sarg/.local/share/virtualenvs/chomper-LZFI31mM/lib/python3.6/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/home/sarg/.local/share/virtualenvs/chomper-LZFI31mM/lib/python3.6/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/sarg/.local/share/virtualenvs/chomper-LZFI31mM/lib/python3.6/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/home/sarg/devel/chomper/chomper/block.py", line 78, in main
    mitmdump_bin_path)
TypeError: enact_block() missing 2 required positional arguments: 'rule' and 'block_end_time'
```