### PR TITLE
Move bash executable comment to top of script to allow for fish shell execution

### DIFF
--- a/bin/chomper
+++ b/bin/chomper
@@ -1,6 +1,6 @@
+#!/bin/bash
 # Copyright: (c) 2018, Aniket Panjwani <aniket@addictedto.tech>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-#!/bin/bash
 SCRIPT=$(readlink -f "$0")
 CURRENTDIR=$(dirname "$SCRIPT")
 PROJECTDIR=$(dirname "$CURRENTDIR")


### PR DESCRIPTION
```bash
# Copyright: (c) 2018, Aniket Panjwani <aniket@addictedto.tech>
# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
#!/bin/bash
```

The first two comment lines for the license in the `chomper/bin/chomper` bash script will cause an error when executed in fish shell.

```
$ /home/david/chomper/bin/chomper nosocial 3
Failed to execute process '/home/david/chomper/bin/chomper'. Reason:
exec: Exec format error
The file '/home/david/chomper/bin/chomper' is marked as an executable but could not be run by the operating system.
```

Moving `#!bin/bash/` to the top of the script allows execution within fish shell.